### PR TITLE
add PollCount option to poll_items

### DIFF
--- a/settings_ini.py
+++ b/settings_ini.py
@@ -64,7 +64,7 @@ w1sensors = {}
 # polling datapoints +++++++++++++++++++
 poll_interval = 30      # seconds. 0 for continuous, set -1 to disable Polling
 poll_items = [
-    # (Name, DpAddr, Len, Scale/Type, Signed)
+    # ([PollCount], Name, DpAddr, Len, Scale/Type, Signed)
 
     # Tabelle fuer Vitocalxxx-G mit Vitotronic 200 (Typ WO1C) (ab 04/2012)
     ("error", 0x0491, 1, 1, False),
@@ -115,7 +115,7 @@ poll_items = [
     ("electrical_energy", 0x1660, 4, 0.1, False),
     ("thermal_power", 0x16A0, 4, 1, False),
     ("electrical_power", 0x16A4, 4, 1, False),
-    ("cop", 0x1680, 1, 0.1, False),
+    (60, "cop", 0x1680, 1, 0.1, False), # Nur jedes 60. mal pollen (wenn poll_interval=30 => 60 x 30 = alle 30 Minuten)
 
 
     # # Tabelle fuer eine Vitodens 300 B3HB


### PR DESCRIPTION
This change adds a PollCount option as a 6th parameter in the poll_items list. PollCount can be used to only refresh items on every n-th poll, e.g. if PollCount is not specified or set to 1, the behavior doesn't change to the current implementation. If poll count is set to 2, this item will only get polled every 2nd time. So if you set the poll interval to 10 seconds and the poll count to 6, it will be polled every 60 seconds approximately (not accounting for wait times of the script).

This change helps to reduce the load on the Optolink interface, by being able to configure only polling certain (non-frequently changed) items less often. E.g. polling the "jahresarbeitszahl" every 60 seconds doesn't make sense, so polling it once / twice a day is enough.

After the script is restarted, every item will be polled once.