### PR TITLE
Fix MQTT Entity Publishing Issue by Removing mqtt_util Dependency

### DIFF
--- a/homeassistant_create_entities.py
+++ b/homeassistant_create_entities.py
@@ -185,10 +185,11 @@ def publish_homeassistant_entities():
     print("Category".ljust(20) + "| Entities Published")
     print("-" * (20 + 20))
     total_entities = sum(entity_count_per_category.values())
-    for category, count in entity_count_per_category.items():
+    for category, count in sorted(entity_count_per_category.items()):
         print(f"{category.ljust(20)}| {str(count).rjust(17)}")
     print("-" * (20 + 20))
     print("Total".ljust(20) + f"| {str(total_entities).rjust(17)}\n")
+
 
 
 

--- a/homeassistant_create_entities.py
+++ b/homeassistant_create_entities.py
@@ -127,18 +127,18 @@ def publish_homeassistant_entities():
     print("\nMQTT Topic & Publishing Settings:\n" + f" mqtt_optolink_base_topic:\t{mqtt_optolink_base_topic}\n" + f" mqtt_ha_discovery_prefix:\t{mqtt_ha_discovery_prefix}\n" + f" mqtt_ha_node_id:\t\t{mqtt_ha_node_id}\n" + f" dp_prefix:\t\t\t{dp_prefix}")
 
     print("\nList of generated datapoint IDs (settings_ini), created from HA entities (homeassistant_entities.json):")
-    entity_count_per_category = {}
+    entity_count_per_domain = {}
     
     for entity in ha_ent["datapoints"]:
         entity_id = re.sub(r"[^0-9a-zA-Z]+", "_", entity["name"]).lower()
         entity_domain = entity.get("domain", "unknown")  # Default to 'unknown' if missing
         print(f"  DP-ID: {entity_id} | HA-Entity: {entity['name']} | Domain: {entity_domain}")
         
-        # Count entities per category
-        if entity_domain in entity_count_per_category:
-            entity_count_per_category[entity_domain] += 1
+        # Count entities per domain
+        if entity_domain in entity_count_per_domain:
+            entity_count_per_domain[entity_domain] += 1
         else:
-            entity_count_per_category[entity_domain] = 1
+            entity_count_per_domain[entity_domain] = 1
 
     # Ensure MQTT connection is established before publishing
     connect_mqtt()
@@ -182,11 +182,11 @@ def publish_homeassistant_entities():
         print(json.dumps(config) + "\n")
 
     # Print Summary
-    print("Category".ljust(20) + "| Entities Published")
+    print("Domain".ljust(20) + "| Entities Published")
     print("-" * (20 + 20))
-    total_entities = sum(entity_count_per_category.values())
-    for category, count in sorted(entity_count_per_category.items()):
-        print(f"{category.ljust(20)}| {str(count).rjust(17)}")
+    total_entities = sum(entity_count_per_domain.values())
+    for domain, count in sorted(entity_count_per_domain.items()):
+        print(f"{domain.ljust(20)}| {str(count).rjust(17)}")
     print("-" * (20 + 20))
     print("Total".ljust(20) + f"| {str(total_entities).rjust(17)}\n")
 

--- a/homeassistant_create_entities.py
+++ b/homeassistant_create_entities.py
@@ -18,40 +18,135 @@
 
 import json
 import re
-import mqtt_util
 import time
+import sys
+import paho.mqtt.client as paho
+import settings_ini
 
-def Create_Entities():
-    with open("homeassistant_entities.json") as js:
-        ha_ent = json.load(js)
-        js.close()
-    mqtt_util.connect_mqtt()
+# Global MQTT Client
+mqtt_client = None
+
+def connect_mqtt():
+    # Connects to the MQTT broker using credentials from settings_ini.py
+    global mqtt_client
+
+    if mqtt_client is None:
+        print(f"\nInitializing MQTT Client for Home Assistant entity creation...")
+        mqtt_client = paho.Client(paho.CallbackAPIVersion.VERSION2, "ha_entities_" + str(int(time.time()*1000)))  # Unique ID
+
+    if mqtt_client.is_connected():
+        print(f" MQTT client is already connected. Skipping reconnection.")
+        return
+
+    try:
+        mqtt_credentials = settings_ini.mqtt.split(':')
+        if len(mqtt_credentials) != 2:
+            raise ValueError(" MQTT settings must be in the format 'host:port'")
+        MQTT_BROKER, MQTT_PORT = mqtt_credentials[0], int(mqtt_credentials[1])
+
+        # Extract username and password
+        mqtt_user_pass = settings_ini.mqtt_user
+        if mqtt_user_pass and mqtt_user_pass.lower() != "none":
+            mqtt_user, mqtt_password = mqtt_user_pass.split(":")
+            mqtt_client.username_pw_set(mqtt_user, mqtt_password)
+            print(f" Connecting as {mqtt_user} to MQTT broker {MQTT_BROKER} on port {MQTT_PORT} for Home Assistant entity creation...")
+        else:
+            print(f" Connecting anonymously to MQTT broker {MQTT_BROKER} on port {MQTT_PORT} for Home Assistant entity creation...")
+
+        mqtt_client.connect(MQTT_BROKER, MQTT_PORT, keepalive=60)
+        mqtt_client.loop_start()
+        print(f" MQTT connected successfully.")
+        
+    except Exception as e:
+        print(f" Error connecting to MQTT broker: {e}")
+        return False
+
+def verify_mqtt_optolink_lwt(timeout=10):
+    # Checks the availability of the Optolink-Splitter by subscribing to the Last Will and Testament (LWT) topic.
+    with open("homeassistant_entities.json") as json_file:
+        ha_ent = json.load(json_file)
+
+    mqtt_optolink_base_topic = ha_ent.get("mqtt_optolink_base_topic", "")
+    LWT_TOPIC = f"{mqtt_optolink_base_topic}LWT"
+
+    try:
+        mqtt_credentials = settings_ini.mqtt.split(":")
+        if len(mqtt_credentials) != 2:
+            raise ValueError("MQTT settings must be in the format 'host:port'")
+        MQTT_BROKER, MQTT_PORT = mqtt_credentials[0], int(mqtt_credentials[1])
+    except Exception as e:
+        print(f"Error in MQTT settings: {e}")
+        return False
+
+    def on_message(client, userdata, message):
+        if message.payload.decode() == "online":
+            print(f" MQTT is connected. Optolink-Splitter LWT reports 'online'. Publishing entities now...\n")
+            client.loop_stop()
+            client.disconnect()
+            userdata["status"] = True
+
+    mqtt_lwt_client = paho.Client(paho.CallbackAPIVersion.VERSION2)
+    mqtt_lwt_client.user_data_set({"status": False})
+    
+    print(f"Subscribing to {LWT_TOPIC} to check Optolink-Splitter state and MQTT connection.")
+    mqtt_lwt_client.on_message = on_message
+    mqtt_lwt_client.connect(MQTT_BROKER, MQTT_PORT, keepalive=10)
+    mqtt_lwt_client.subscribe(LWT_TOPIC)
+    mqtt_lwt_client.loop_start()
+
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        if mqtt_lwt_client._userdata["status"]:
+            return True
+        time.sleep(3)
+
+    print(f" Error: Optolink-Splitter LWT did not report 'online'. Ensure that optolinkvs2_switch.py (or the corresponding service) is running and retry.")
+    mqtt_lwt_client.loop_stop()
+    mqtt_lwt_client.disconnect()
+    return False
+
+def publish_homeassistant_entities():
+    # Reads entity definitions from homeassistant_entities.json and publishes MQTT discovery messages to Home Assistant.
+    with open("homeassistant_entities.json") as json_file:
+        ha_ent = json.load(json_file)
+
+    if "datapoints" not in ha_ent:
+        print("Error: 'datapoints' missing in homeassistant_entities.json")
+        return
+
+    # Ensure MQTT connection is established before publishing
+    connect_mqtt()
+
     mqtt_optolink_base_topic = ha_ent.get("mqtt_optolink_base_topic", "")
     mqtt_ha_discovery_prefix = ha_ent.get("mqtt_ha_discovery_prefix", "")
     mqtt_ha_node_id = ha_ent.get("mqtt_ha_node_id", "")
     dp_prefix = ha_ent.get("dp_prefix", "")
-    
-    ## Print out all prefix information
+
     print(f"\nPrefix information \n  mqtt_optolink_base_topic: {mqtt_optolink_base_topic} \n  mqtt_ha_discovery_prefix: {mqtt_ha_discovery_prefix} \n  mqtt_ha_node_id: {mqtt_ha_node_id} \n  dp_prefix: {dp_prefix}")
-    ## Print out all datapoints and their name conversions
+
     print("\nAll generated IDs from Entities")
     for entity in ha_ent["datapoints"]:
-        id = re.sub(r"[^0-9a-zA-Z]+", "_", entity["name"]).lower()
-        print(f"  ID: {id} / Entity: {entity['name']}")
-    print("\n\n")
-     
+        entity_id = re.sub(r"[^0-9a-zA-Z]+", "_", entity["name"]).lower()
+        print(f"  ID: {entity_id} / Entity: {entity['name']}")
+    print("\n")
+
+    # Check if Optolink-Splitter is online
+    if not verify_mqtt_optolink_lwt():
+        print("WARNING: Optolink-Splitter is not online. Proceeding without publishing.")
+        return
+
     for entity in ha_ent["datapoints"]:
-        id = re.sub(r"[^0-9a-zA-Z]+", "_", entity["name"]).lower()
+        entity_id = re.sub(r"[^0-9a-zA-Z]+", "_", entity["name"]).lower()
         config = {
-            "object_id": ha_ent["dp_prefix"] + id,
-            "unique_id": ha_ent["dp_prefix"] + id,
+            "object_id": ha_ent["dp_prefix"] + entity_id,
+            "unique_id": ha_ent["dp_prefix"] + entity_id,
             "device": ha_ent["device"],
             "availability_topic": ha_ent['mqtt_optolink_base_topic'] + "LWT"
         }
-        
+
         if entity["domain"] != "climate":
-            config["state_topic"] = ha_ent["mqtt_optolink_base_topic"] + id
-        
+            config["state_topic"] = ha_ent["mqtt_optolink_base_topic"] + entity_id
+
         for key, value in entity.items():
             if key != "domain":
                 if key.endswith("_topic"):
@@ -59,20 +154,18 @@ def Create_Entities():
                 else:
                     config[key] = value
 
-        
-        ## MQTT-Publishing
-        mqtt_util.mqtt_client.publish(
-            f"{mqtt_ha_discovery_prefix}/{entity['domain']}/{ha_ent['mqtt_ha_node_id']}{id}/config",
+        mqtt_client.publish(
+            f"{mqtt_ha_discovery_prefix}/{entity['domain']}/{ha_ent['mqtt_ha_node_id']}{entity_id}/config",
             json.dumps(config),
             retain=True,
         )
-        
+        time.sleep(0.5) # Processing time for Home Assistant Discovery
+                
+        # The following printouts are for debugging of the published discovery messages. Please feel free to comment out.
         print(f"Processed entity: {entity['name']}")
         print(f"   {mqtt_ha_discovery_prefix}/{entity['domain']}/{ha_ent['mqtt_ha_node_id']}{id}/config")
-        print(json.dumps(config))
-        print("\n")
-        
-#        time.sleep(3) ## Uncomment only if necessary: Might be necessary to give HA some time to process the message before the next message arrives. Can lead to MQTT disconnects and entities not being created.
-   
+        print(json.dumps(config) + "\n")
+
 if __name__ == "__main__":
-    Create_Entities()
+    print("\nStarting Home Assistant Entity Creation...\n")
+    publish_homeassistant_entities()

--- a/homeassistant_create_entities.py
+++ b/homeassistant_create_entities.py
@@ -124,7 +124,7 @@ def publish_homeassistant_entities():
     mqtt_ha_node_id = ha_ent.get("mqtt_ha_node_id", "")
     dp_prefix = ha_ent.get("dp_prefix", "")
 
-    print("\n==== MQTT Topic & Publishing Settings ====\n" + f"mqtt_optolink_base_topic:\t{mqtt_optolink_base_topic}\n" + f"mqtt_ha_discovery_prefix:\t{mqtt_ha_discovery_prefix}\n" + f"mqtt_ha_node_id:\t\t{mqtt_ha_node_id}\n" + f"dp_prefix:\t\t\t{dp_prefix}")
+    print("\nMQTT Topic & Publishing Settings:\n" + f" mqtt_optolink_base_topic:\t{mqtt_optolink_base_topic}\n" + f" mqtt_ha_discovery_prefix:\t{mqtt_ha_discovery_prefix}\n" + f" mqtt_ha_node_id:\t\t{mqtt_ha_node_id}\n" + f" dp_prefix:\t\t\t{dp_prefix}")
 
     print("\nList of generated datapoint IDs (settings_ini), created from HA entities (homeassistant_entities.json):")
     entity_count_per_category = {}


### PR DESCRIPTION
The previous implementation using `mqtt_util` caused the Optolink-Splitter to go offline (`LWT=Offline`) while publishing entities. Home Assistant only accepts new entities from devices with `LWT=Online`.  This was especially problematic for large entity lists, as it was more likely that Home Assistant detected the offline state, leading to entity creation failures.

- **Removed dependency on `mqtt_util`**  
- **Implemented a standalone MQTT client that:**  
  - Reads the MQTT broker address and credentials from `settings_ini.py`  
  - Retrieves the `mqtt_base_topic` from `homeassistant_entities.json`  
- **Added a pre-check for LWT status before publishing entities:**  
  - The script verifies that `LWT=Online`  
  - If `LWT=Offline`, the script aborts with an error message instructing the user to start the Optolink-Splitter  

This ensures reliable entity creation and prevents Home Assistant from rejecting new entities due to offline status.  