### PR TITLE
Upgraded Home Assistant Create Entities 

### DIFF
--- a/homeassistant_create_entities.py
+++ b/homeassistant_create_entities.py
@@ -273,10 +273,10 @@ def check_entities_and_print_entity_table(entity_data):
         print(' - "Resp" is the response to commands sent by the Optolink-Splitter, and therefore has no direct counterpart in poll_items.\n')
 
 
-        print("For other entities, especially SENSORs, this could be critical, as they will not attach to a value and will not be displayed in Home Assistant.")
-        print("To prevent this issue, PLEASE CHECK SPELLING AND ENSURE THAT POLL_ITEMS ARE IN LOWERCASE.\n")
-
-        print("PLEASE ENSURE ALL MQTT-RELATED VALUES (E.G., POLL_ITEMS AND MQTT_OPTOLINK_BASE_TOPIC) ARE IN LOWERCASE!\n")
+        print("For other entities, especially SENSORs, this could be critical, as they will not attach to a value and will not be displayed in Home Assistant.\n")
+        
+        print("To prevent this issue, PLEASE CHECK SPELLING AND ENSURE THAT POLL_ITEMS ARE IN LOWERCASE.")
+        print("Recommendation: Keep all MQTT-related values (e.g. mqtt_topic) in lowercase!\n")
 
         print("\n" * 4 + "Continuing script...")
 
@@ -310,7 +310,7 @@ def publish_homeassistant_entities():
 
     # Check if Optolink-Splitter is online before proceeding
     if not verify_mqtt_optolink_lwt():
-        print(" ERROR: Optolink-Splitter is offline. Exiting script to prevent MQTT discovery issues.")
+        print("ERROR: Optolink-Splitter is offline. Exiting script to prevent MQTT discovery issues.")
         sys.exit(1)
 
     print("\nPublishing entities now...\n")
@@ -352,6 +352,7 @@ def publish_homeassistant_entities():
             for key, value in current_entity.items():
                 if key != "domain":
                     if key.endswith("_topic"):
+                        config[key] = mqtt_optolink_base_topic + value
                         config[key] = mqtt_optolink_base_topic + value
                     else:
                         config[key] = value


### PR DESCRIPTION
The script now checks if all entities from homeassistant_entities.json are present in poll_items (case-sensitive). The output is displayed in an overview table, and if there is a mismatch, a warning with recommendations is shown.

Two example outputs are provided below:

**Successful: Optolink-Splitter up and running**
```
python homeassistant_create_entities.py 
poll_list made, 69 items

Starting Home Assistant Entity Creation...

Reading homeassistant_entities from homeassistant_entities.json
Reading poll_list from poll_list.py or settings_ini.py


List of generated datapoint IDs (settings_ini), created from HA entities (homeassistant_entities.json):

        |                     | Generated         | DP found     
Domain  | HA-Entity from json | Datapoint (DP)    | in poll_list?
climate (1) -----------------------------------------------------
        | HK2 Thermostat      | hk2_thermostat    | No           
sensor (3) ------------------------------------------------------
        | Aussentemp          | aussentemp        | Yes          
        | COP                 | cop               | Yes          
        | Resp                | resp              | No           
switch (1) ------------------------------------------------------
        | Durchlauferhitzer   | durchlauferhitzer | No           
text (1) --------------------------------------------------------
        | Cmnd                | cmnd              | No           
-----------------------------------------------------------------
TOTAL ENTITIES: 6





!!! WARNING !!!
One or more entities from your homeassistant_entities.json were not found in your poll_items (settings_ini.py or poll_list.py).

Possible causes:
 - Thermostats consist of multiple values with no direct counterpart in poll_items.
 - Switches consist of multiple values with no direct counterpart in poll_items.
 - "Cmnd" refers to commands sent from Home Assistant to the Optolink-Splitter, and therefore has no direct counterpart in poll_items.
 - "Resp" is the response to commands sent by the Optolink-Splitter, and therefore has no direct counterpart in poll_items.

For other entities, especially SENSORs, this could be critical, as they will not attach to a value and will not be displayed in Home Assistant.

To prevent this issue, PLEASE CHECK SPELLING AND ENSURE THAT POLL_ITEMS ARE IN LOWERCASE.
Recommendation: Keep all MQTT-related values (e.g. mqtt_topic) in lowercase!





Continuing script...

Initializing MQTT Client for Home Assistant entity creation...
 Connecting anonymously to MQTT broker xxx.xxx.xxx.xxx on port 1883...
 MQTT connected successfully.
 Subscribing to viessmann/vitocal200/LWT...
 MQTT is connected. Optolink-Splitter LWT reports 'online'.

Publishing entities now...

MQTT Topic & Publishing Settings:
 mqtt_optolink_base_topic:      viessmann/vitocal200/
 mqtt_ha_discovery_prefix:      homeassistant
 mqtt_ha_node_id:               vitocal200/
 dp_prefix:                     vitocal200_

[6/6]

Finished Home Assistant Entity Creation.
```




**Error: Optolink-Splitter is offline**

```
(...)

Continuing script...

Initializing MQTT Client for Home Assistant entity creation...
 Connecting anonymously to MQTT broker xxx.xxx.xxx.xxx on port 1883...
 MQTT connected successfully.
 Subscribing to viessmann/vitocal200/LWT...
 ERROR: Optolink-Splitter LWT did not report 'online'.
 Ensure optolinkvs2_switch.py (or the corresponding service) is running.
ERROR: Optolink-Splitter is offline. Exiting script to prevent MQTT discovery issues.
```