### PR TITLE
Enable use of MQTT retain flag and make it configurable

### DIFF
--- a/mqtt_util.py
+++ b/mqtt_util.py
@@ -88,7 +88,7 @@ def publish_read(name, addr, value):
     if(mqtt_client != None):
         publishStr = settings_ini.mqtt_fstr.format(dpaddr = addr, dpname = name)
         # send
-        ret = mqtt_client.publish(settings_ini.mqtt_topic + "/" + publishStr, value)    
+        ret = mqtt_client.publish(settings_ini.mqtt_topic + "/" + publishStr, value, retain=settings_ini.mqtt_retain)    
         if(verbose): print(ret)
 
 def publish_response(resp:str):

--- a/settings_ini.py
+++ b/settings_ini.py
@@ -27,7 +27,7 @@ mqtt_topic = "Vito"              # MQTT topic for publishing data (default: "Vit
 mqtt_fstr = "{dpname}"           # Format string for MQTT messages (default: "{dpname}", alternative: "{dpaddr:04X}_{dpname}")
 mqtt_listen = "Vito/cmnd"        # MQTT topic for incoming commands (default: "Vito/cmnd", set None to disable)
 mqtt_respond = "Vito/resp"       # MQTT topic for responses (default: "Vito/resp", set None to disable)
-mqtt_retain = True               # Publish MQTT message with retain set
+mqtt_retain = False              # Publish MQTT message with retain set
 
 # TCP/IP ++++++++++++++++++++++++++
 tcpip_port = 65234               # TCP/IP port for communication (default: 65234, used by Viessdata; set None to disable TCP/IP)

--- a/settings_ini.py
+++ b/settings_ini.py
@@ -27,6 +27,7 @@ mqtt_topic = "Vito"              # MQTT topic for publishing data (default: "Vit
 mqtt_fstr = "{dpname}"           # Format string for MQTT messages (default: "{dpname}", alternative: "{dpaddr:04X}_{dpname}")
 mqtt_listen = "Vito/cmnd"        # MQTT topic for incoming commands (default: "Vito/cmnd", set None to disable)
 mqtt_respond = "Vito/resp"       # MQTT topic for responses (default: "Vito/resp", set None to disable)
+mqtt_retain = True               # Publish MQTT message with retain set
 
 # TCP/IP ++++++++++++++++++++++++++
 tcpip_port = 65234               # TCP/IP port for communication (default: 65234, used by Viessdata; set None to disable TCP/IP)


### PR DESCRIPTION
I like retaining messages in MQTT to have a history of values in case something happens. Retain was only used for last will so I added it as a general setting and turned it on by default.