### PR TITLE
Add a basic pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: main CI
 
 on:
   push:
+  pull_request:
+    branches:
+      - develop
+      - main
+      - test_f18m
 
 jobs:
   # -------------------------------------------------------------------------- 


### PR DESCRIPTION
This PR is adding a basic Github Actions pipeline to this project that makes sure every push in the repo is passing:
* Black formatter (see https://black.readthedocs.io/en/stable/ )
* Ruff static code analyzer (see https://docs.astral.sh/ruff/)

These are typical steps for modern projects.
Right now optolink-splitter does not pass any of these checks.
I can submit PRs later to get the check passing, but first wanted to see the reaction to this PR :)

To get an idea of how the (opinionated) formatter would require the code to look like you can run:

```
pip3 install black
cd optolink-splitter
black .
git diff
```