### PR TITLE
ha_publish improvements

### DIFF
--- a/ha_shared_config.py.example
+++ b/ha_shared_config.py.example
@@ -38,6 +38,7 @@ shared_config = {
         "manufacturer": "Viessmann"
     },
     "node_id": "vitocal",
+    "entity_prefix": "vitocal_200g",
     "beautifier" : {"search"  : ["primaer","sekundaer","rueck","energy", "heating","water", "thermal",  "electric", "kaelte", "kuehl", "ueber", "fluessig", "oeff"],
                     "replace" : ["primär", "sekundär", "rück", "energie","heizen", "wasser","thermisch","elektrisch", "kälte", "kühl", "über", "flüssig", "öff"],
                     },


### PR DESCRIPTION
Hi there, 

I was really happy to find out the latest HA publish feature, this is great!

While trying to use it I had few troubles with my MQTT setup, as I use TLS encryption. The `optolink-splitter` does support it already, but `ha_publish` was initializing the connection by itself. I took a moment and adopted it to use the `mqtt_util`, so the same way how to connect to MQTT broker can be used in both places.

I also did improve the HA publish logic a little as well - as the "`unique_id`" of the published entities has to be unique globally in HA (across all possible integrations configured in HA) I though that "`node_id`" could be a good idea to be part of the generated "`unique_id`". The discovery message contains now  "`default_entity_id`" too, which is kind of suggestion for Home Assistant how the entity should be called once it's added to the system ("`unique_id`" does not affect how the entities are named within the HA system).

Maybe these improvements can also help someone else as well.

Thanks for keeping the project alive - it's really helpful!
Nobwyn